### PR TITLE
test: Userのリクエストスペックを追加

### DIFF
--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -15,13 +15,8 @@ require 'rails_helper'
 RSpec.describe '/users', type: :request do
   # User. As you add validations to User, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) do
-    skip('Add a hash of attributes valid for your model')
-  end
-
-  let(:invalid_attributes) do
-    skip('Add a hash of attributes invalid for your model')
-  end
+  let(:valid_attributes) { { name: 'test', email:'test@test.com' } }
+  let(:invalid_attributes) { { name: '', email:'' } }
 
   describe 'GET /index' do
     it 'renders a successful response' do
@@ -84,15 +79,14 @@ RSpec.describe '/users', type: :request do
 
   describe 'PATCH /update' do
     context 'with valid parameters' do
-      let(:new_attributes) do
-        skip('Add a hash of attributes valid for your model')
-      end
+      let(:new_attributes) { { name: 'test1', email:'test1@test1.com' } }
 
       it 'updates the requested user' do
         user = User.create! valid_attributes
-        patch user_url(user), params: { user: new_attributes }
-        user.reload
-        skip('Add assertions for updated state')
+        expect do
+          patch user_url(user), params: { user: new_attributes }
+          user.reload
+        end.to change { User.find(user.id).name }.from(user.name).to(new_attributes[:name])
       end
 
       it 'redirects to the user' do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -15,8 +15,8 @@ require 'rails_helper'
 RSpec.describe '/users', type: :request do
   # User. As you add validations to User, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { { name: 'test', email:'test@test.com' } }
-  let(:invalid_attributes) { { name: '', email:'' } }
+  let(:valid_attributes) { { name: 'test', email: 'test@test.com' } }
+  let(:invalid_attributes) { { name: '', email: '' } }
 
   describe 'GET /index' do
     it 'renders a successful response' do
@@ -79,13 +79,12 @@ RSpec.describe '/users', type: :request do
 
   describe 'PATCH /update' do
     context 'with valid parameters' do
-      let(:new_attributes) { { name: 'test1', email:'test1@test1.com' } }
+      let(:new_attributes) { { name: 'test1', email: 'test1@test1.com' } }
 
       it 'updates the requested user' do
         user = User.create! valid_attributes
         expect do
           patch user_url(user), params: { user: new_attributes }
-          user.reload
         end.to change { User.find(user.id).name }.from(user.name).to(new_attributes[:name])
       end
 
@@ -102,6 +101,13 @@ RSpec.describe '/users', type: :request do
         user = User.create! valid_attributes
         patch user_url(user), params: { user: invalid_attributes }
         expect(response).to be_successful
+      end
+
+      it 'does not updates the user infomation' do
+        user = User.create! valid_attributes
+        expect do
+          patch user_url(user), params: { user: invalid_attributes }
+        end.not_to change(User.find(user.id), :name)
       end
     end
   end


### PR DESCRIPTION
close
#8 
## 概要

- Userのリクエストスペックを追加
- Userコントローラーに対する各HTTPリクエストの送信の結果が問題ないことの確認が可能となる

## 修正内容の検証方法

`docker-compose up -d`
`bundle exec rake db:setup`
`bundle exec rspec`


## この修正が正しい理由

- テストが正常に完了するため
