### PR TITLE
feat: User一覧へのPagination機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'jbuilder', '2.10.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '1.4.6', require: false
 
+# add
+gem 'kaminari', '1.1.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.1.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.0)
+      kaminari-activerecord (= 1.1.0)
+      kaminari-core (= 1.1.0)
+    kaminari-actionview (1.1.0)
+      actionview
+      kaminari-core (= 1.1.0)
+    kaminari-activerecord (1.1.0)
+      activerecord
+      kaminari-core (= 1.1.0)
+    kaminari-core (1.1.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -245,6 +257,7 @@ DEPENDENCIES
   byebug
   capybara (= 3.33.0)
   jbuilder (= 2.10.0)
+  kaminari (= 1.1.0)
   listen (= 3.2.1)
   pg (= 1.2.3)
   puma (= 4.3.5)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @users = User.all
+    @users = User.order(id: :asc).page(params[:page])
   end
 
   # GET /users/1

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,16 +13,17 @@
 
   <tbody>
     <% @users.each do |user| %>
-      <tr>
-        <td><%= user.name %></td>
-        <td><%= user.email %></td>
-        <td><%= link_to 'Show', user %></td>
-        <td><%= link_to 'Edit', edit_user_path(user) %></td>
-        <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
+    <tr>
+      <td><%= user.name %></td>
+      <td><%= user.email %></td>
+      <td><%= link_to 'Show', user %></td>
+      <td><%= link_to 'Edit', edit_user_path(user) %></td>
+      <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+    </tr>
     <% end %>
   </tbody>
 </table>
+<%= paginate @users %>
 
 <br>
 

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
close
#14 

## 概要

- User一覧へのPagination機能追加
- User一覧画面での表示数を管理できるようになる

## 修正内容の検証方法

```
docker-compose up -d
bundle exec rake db:setup
rails s
```

ブラウザで下記のURLにアクセス
http://localhost:3000/users

## この修正が正しい理由

- 設定通りに表示されている
